### PR TITLE
Parametrize Saltstack version to install

### DIFF
--- a/simple-bootstrap.sh
+++ b/simple-bootstrap.sh
@@ -2,10 +2,14 @@
 
 set -eux
 
+#########
+# Parameters
+SALT_VERSION=${SALT_VERSION:-2018.3}
+
 ##########
 # Step 1: Install Saltstack and git
 wget -O bootstrap-salt.sh https://bootstrap.saltstack.com
-sh bootstrap-salt.sh
+sh bootstrap-salt.sh stable ${SALT_VERSION}
 # disable the service until configured
 service salt-minion stop
 # the bootstrap formula might need git installed..


### PR DESCRIPTION
Parametrize Saltstack version to install and pin version 2018.3.

Testing in vagrant:

a) Without a pinned version
```
vagrant@ubuntu-xenial:$ ./simple-bootstrap.sh
+ SALT_VERSION=2018.3

+ wget -O bootstrap-salt.sh https://bootstrap.saltstack.com
--2019-10-07 19:27:10--  https://bootstrap.saltstack.com/
...
Saving to: ‘bootstrap-salt.sh’

bootstrap-salt.sh                   100%[==================================================================>] 260.18K   857KB/s    in 0.3s    

2019-10-07 19:27:11 (857 KB/s) - ‘bootstrap-salt.sh’ saved [266421/266421]

+ sh bootstrap-salt.sh stable 2018.3
 *  INFO: Running version: 2019.05.20
 *  INFO: Executed by: sh
 *  INFO: Command line: 'bootstrap-salt.sh stable 2018.3'
```

b) With a pinned version
```
vagrant@ubuntu-xenial:$ SALT_VERSION=2019.2 ./simple-bootstrap.sh
+ SALT_VERSION=2019.2

+ wget -O bootstrap-salt.sh https://bootstrap.saltstack.com
--2019-10-07 19:30:45--  https://bootstrap.saltstack.com/
...
Saving to: ‘bootstrap-salt.sh’
bootstrap-salt.sh                   100%[==================================================================>] 260.18K   876KB/s    in 0.3s    

2019-10-07 19:30:46 (876 KB/s) - ‘bootstrap-salt.sh’ saved [266421/266421]

+ sh bootstrap-salt.sh stable 2019.2
 *  INFO: Running version: 2019.05.20
 *  INFO: Executed by: sh
 *  INFO: Command line: 'bootstrap-salt.sh stable 2019.2'
```