### PR TITLE
Fixes saltstack installation issue

### DIFF
--- a/simple-bootstrap.sh
+++ b/simple-bootstrap.sh
@@ -4,7 +4,7 @@ set -eux
 
 #########
 # Parameters
-SALT_VERSION=${SALT_VERSION:-2018.3}
+SALT_VERSION=${SALT_VERSION:-2019.2}
 
 ##########
 # Step 1: Install Saltstack and git


### PR DESCRIPTION
This fixes the following error which we get currently:
```
amazon-ebs:  * ERROR: https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub failed to download to /tmp/salt-gpg-2QoGbsZu.pub
amazon-ebs:  * ERROR: Failed to run install_ubuntu_stable_deps()!!!
```

On debugging this, it seems that public key doesn't exist for the
version 2018.3. But it seems to work for the version 2019.2.